### PR TITLE
Pass opts to ws constructor to allow customization

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function Socket (url, opts) {
   self._interval = null
 
   try {
-    self._ws = new WebSocket(self.url)
+    self._ws = new WebSocket(self.url, typeof window === 'undefined' ? opts : null)
   } catch (err) {
     process.nextTick(function () {
       self._onError(err)


### PR DESCRIPTION
It can be handy to allow users to pass options to ws websockets in node. 

The options are not documented but you can find it in [the source](https://github.com/websockets/ws/blob/master/lib/WebSocket.js#L571)