### PR TITLE
Use ws module when available to benefit from options in electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var inherits = require('inherits')
 var stream = require('readable-stream')
 var ws = require('ws') // websockets in node - will be empty object in browser
 
-var _WebSocket = typeof WebSocket !== 'undefined' ? WebSocket : ws
+var _WebSocket = typeof ws !== 'function' ? WebSocket : ws
 
 inherits(Socket, stream.Duplex)
 
@@ -37,7 +37,7 @@ function Socket (url, opts) {
   self._interval = null
 
   try {
-    if (typeof WebSocket === 'undefined') {
+    if (typeof ws === 'function') {
       // `ws` package accepts options
       self._ws = new _WebSocket(self.url, opts)
     } else {


### PR DESCRIPTION
As discussed in #12, it can be useful to be able to use ws module in electron (httpAgent for instance).

I simply use ws over native WebSocket when available, I don't think we need to have a condition on options or so.