### PR TITLE
Update ws dependency >= 3.3.1 per https://nodesecurity.io/advisories/550

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "randombytes": "^2.0.3",
     "readable-stream": "^2.0.5",
     "safe-buffer": "^5.0.1",
-    "ws": "^2.0.0"
+    "ws": "^3.3.1"
   },
   "devDependencies": {
     "browserify": "^14.0.0",


### PR DESCRIPTION
See https://nodesecurity.io/advisories/550

All tests pass w/ `npm run test` 😄 