### PR TITLE
Use queueMicrotask instead of setTimeout(fn, 0)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const debug = require('debug')('simple-websocket')
 const randombytes = require('randombytes')
 const stream = require('readable-stream')
+const queueMicrotask = require('queue-microtask') // TODO: remove when Node 10 is not supported
 const ws = require('ws') // websockets in node - will be empty object in browser
 
 const _WebSocket = typeof ws !== 'function' ? WebSocket : ws
@@ -59,7 +60,7 @@ class Socket extends stream.Duplex {
           this._ws = new _WebSocket(opts.url)
         }
       } catch (err) {
-        process.nextTick(() => this.destroy(err))
+        queueMicrotask(() => this.destroy(err))
         return
       }
     }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "debug": "^4.1.1",
+    "queue-microtask": "^1.1.0",
     "randombytes": "^2.0.3",
     "readable-stream": "^3.1.1",
     "ws": "^7.0.0"


### PR DESCRIPTION
Modern browsers throttle timers severely, so setTimeout(…, 0) usually takes at least 4ms to run. Furthermore, the throttling gets even worse if the page is backgrounded.

queueMicrotask has none of these problems. But it's not available in Node 10 or earlier, and very old browsers. [`queue-microtask`](https://github.com/feross/queue-microtask) provides a no dependency, 6 line fallback for these environments.

Eventually, we can remove the package when we don't support Node 10 anymore.