### PR TITLE
Use object shorthand for properties

### DIFF
--- a/test/node/server.js
+++ b/test/node/server.js
@@ -8,7 +8,7 @@ test('socket server', function (t) {
   t.plan(3)
 
   var port = 6789
-  var server = new Server({ port: port })
+  var server = new Server({ port })
 
   server.on('connection', function (socket) {
     t.equal(typeof socket.read, 'function') // stream function is present


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility:  This syntax is supported everywhere `class`es is ✅ 