### PR TITLE
fix: replaced ws import with isomorphic-ws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/index.js
+++ b/index.js
@@ -5,9 +5,7 @@ const debug = require('debug')('simple-websocket')
 const randombytes = require('randombytes')
 const stream = require('readable-stream')
 const queueMicrotask = require('queue-microtask') // TODO: remove when Node 10 is not supported
-const ws = require('ws') // websockets in node - will be empty object in browser
-
-const _WebSocket = typeof ws !== 'function' ? WebSocket : ws
+const _WebSocket = require('isomorphic-ws') // isomorphic-ws will automatically choose between the node or the browser version
 
 const MAX_BUFFERED_AMOUNT = 64 * 1024
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "debug": "^4.3.1",
+    "isomorphic-ws": "^4.0.1",
     "queue-microtask": "^1.2.2",
     "randombytes": "^2.1.0",
     "readable-stream": "^3.6.0",


### PR DESCRIPTION
Using isomorphic-ws wrapper we can ensure that the library works seamlessly in node or in the browser even with newer versions of ws.

The library was not working properly with ws@7.5.6 because the import in that version returns a function that throws an error even if you are in the browser, making the if condition at the beginning of the file to always return the node version.