### PR TITLE
fix: return `this` from `destroy()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ class Socket extends stream.Duplex {
   // See: https://github.com/nodejs/readable-stream/issues/283
   destroy (err) {
     this._destroy(err, () => {})
+    return this
   }
 
   _destroy (err, cb) {


### PR DESCRIPTION
For consistency with Node readable stream implementation, `destroy()` should likely return `this` - see https://nodejs.org/api/stream.html#readabledestroyerror and https://nodejs.org/api/stream.html#writabledestroyerror

**Context**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473