### PR TITLE
fix: migrate to streamx drop readable-stream

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,5 +1,4 @@
 sauce_connect: true
-loopback: airtap.local
 browsers:
   - name: chrome
     version: latest
@@ -13,3 +12,13 @@ browsers:
     version: latest
   - name: android
     version: latest
+presets:
+  local:
+    providers: airtap-manual
+    browsers:
+      - name: manual
+browserify:
+  - transform: babelify
+    global: true
+    presets: ['@babel/preset-env']
+    plugins: ['@babel/plugin-syntax-import-assertions']

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "debug": "^4.3.1",
     "queue-microtask": "^1.2.2",
     "randombytes": "^2.1.0",
-    "readable-stream": "^3.6.0",
+    "streamx": "^2.12.4",
     "ws": "^7.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "email": "feross@feross.org",
     "url": "https://feross.org"
   },
+  "type": "module",
   "browser": {
     "ws": false
   },
@@ -14,21 +15,25 @@
     "url": "https://github.com/feross/simple-websocket/issues"
   },
   "dependencies": {
-    "debug": "^4.3.1",
-    "queue-microtask": "^1.2.2",
-    "randombytes": "^2.1.0",
-    "streamx": "^2.12.4",
-    "ws": "^7.4.2"
+    "debug": "^4.3.4",
+    "queue-microtask": "^1.2.3",
+    "streamx": "^2.13.2",
+    "uint8-util": "^2.1.6",
+    "ws": "^8.12.0"
   },
   "devDependencies": {
-    "airtap": "^3.0.0",
+    "@babel/core": "^7.20.12",
+    "@babel/preset-env": "^7.20.2",
+    "airtap": "^4.0.4",
+    "airtap-manual": "^1.0.0",
     "babel-eslint": "^10.1.0",
-    "babel-minify": "^0.5.1",
+    "babel-minify": "^0.5.2",
+    "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "prettier-bytes": "^1.0.4",
     "speedometer": "^1.1.0",
     "standard": "*",
-    "tape": "^5.1.1"
+    "tape": "^5.6.3"
   },
   "homepage": "https://github.com/feross/simple-websocket",
   "keywords": [
@@ -50,7 +55,7 @@
     "size": "npm run build && cat simplewebsocket.min.js | gzip | wc -c",
     "test": "standard && npm run test-node && npm run test-browser",
     "test-browser": "airtap -- test/*.js",
-    "test-browser-local": "airtap --local -- test/*.js",
+    "test-browser-local": "airtap --preset local -- test/*.js",
     "test-node": "tape test/*.js test/node/*.js"
   },
   "standard": {

--- a/perf/send.js
+++ b/perf/send.js
@@ -3,8 +3,8 @@
 
 // 6.7MB
 
-const Socket = require('../')
-const stream = require('readable-stream')
+import Socket from '../index.js'
+import stream from 'readable-stream'
 
 const buf = Buffer.alloc(1000)
 

--- a/perf/server.js
+++ b/perf/server.js
@@ -1,12 +1,12 @@
 // run in a terminal, look at Node.js console for speed
 
-const prettierBytes = require('prettier-bytes')
-const speedometer = require('speedometer')
-const ws = require('ws')
+import prettierBytes from 'prettier-bytes'
+import speedometer from 'speedometer'
+import { Server } from 'ws'
 
 const speed = speedometer()
 
-const server = new ws.Server({
+const server = new Server({
   perMessageDeflate: false,
   port: 8080
 })

--- a/server.js
+++ b/server.js
@@ -1,8 +1,8 @@
-const events = require('events')
-const Socket = require('./')
-const WebSocketServer = require('ws').Server
+import events from 'events'
+import Socket from './index.js'
+import { WebSocketServer } from 'ws'
 
-class SocketServer extends events.EventEmitter {
+export default class SocketServer extends events.EventEmitter {
   constructor (opts) {
     super()
 
@@ -56,5 +56,3 @@ class SocketServer extends events.EventEmitter {
     this.close()
   }
 }
-
-module.exports = SocketServer

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,6 @@
-const common = require('./common')
-const Socket = require('../')
-const test = require('tape')
+import common from './common.js'
+import Socket from '../index.js'
+import test from 'tape'
 
 test('detect WebSocket support', function (t) {
   t.equal(Socket.WEBSOCKET_SUPPORT, true, 'websocket support')
@@ -28,8 +28,8 @@ test('echo string', function (t) {
     t.pass('connect emitted')
     socket.send('sup!')
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.equal(data.toString(), 'sup!')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.equal(Buffer.from(data).toString(), 'sup!')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -49,8 +49,8 @@ test('echo string (opts.url version)', function (t) {
     t.pass('connect emitted')
     socket.send('sup!')
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.equal(data.toString(), 'sup!')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.equal(Buffer.from(data).toString(), 'sup!')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -68,8 +68,8 @@ test('echo Buffer', function (t) {
     t.pass('connect emitted')
     socket.send(Buffer.from([1, 2, 3]))
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -89,8 +89,8 @@ test('echo Uint8Array', function (t) {
     socket.on('data', function (data) {
       // binary types always get converted to Buffer
       // See: https://github.com/feross/simple-peer/issues/138#issuecomment-278240571
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -108,8 +108,8 @@ test('echo ArrayBuffer', function (t) {
     t.pass('connect emitted')
     socket.send(new Uint8Array([1, 2, 3]).buffer)
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,4 @@
-const Server = require('../server')
+import Server from '../server.js'
 
 const server = new Server({ port: 0, objectMode: true })
 
@@ -8,5 +8,7 @@ server.on('connection', function (socket) {
   })
 })
 
-exports.SERVER_URL = 'ws://localhost:' + server._server._server.address().port
-exports.server = server
+export default {
+  SERVER_URL: 'ws://localhost:' + server._server._server.address().port,
+  server
+}

--- a/test/common.js
+++ b/test/common.js
@@ -1,1 +1,12 @@
-exports.SERVER_URL = 'wss://echo.websocket.org'
+const Server = require('../server')
+
+const server = new Server({ port: 0, objectMode: true })
+
+server.on('connection', function (socket) {
+  socket.on('data', function (data) {
+    socket.write(data)
+  })
+})
+
+exports.SERVER_URL = 'ws://localhost:' + server._server._server.address().port
+exports.server = server

--- a/test/custom-socket.js
+++ b/test/custom-socket.js
@@ -1,9 +1,9 @@
 /* global WebSocket */
 
-const common = require('./common')
-const Socket = require('../')
-const test = require('tape')
-const ws = require('ws') // websockets in node - will be empty object in browser
+import common from './common.js'
+import Socket from '../index.js'
+import test from 'tape'
+import ws from 'ws' // websockets in node - will be empty object in browser
 
 const _WebSocket = typeof ws !== 'function' ? WebSocket : ws
 
@@ -35,8 +35,8 @@ test('echo string (with custom socket)', function (t) {
     t.pass('connect emitted')
     socket.send('sup!')
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.equal(data.toString(), 'sup!')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.equal(Buffer.from(data).toString(), 'sup!')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -57,8 +57,8 @@ test('echo Buffer (with custom socket)', function (t) {
     t.pass('connect emitted')
     socket.send(Buffer.from([1, 2, 3]))
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -81,8 +81,8 @@ test('echo Uint8Array (with custom socket)', function (t) {
     socket.on('data', function (data) {
       // binary types always get converted to Buffer
       // See: https://github.com/feross/simple-peer/issues/138#issuecomment-278240571
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -103,8 +103,8 @@ test('echo ArrayBuffer (with custom socket)', function (t) {
     t.pass('connect emitted')
     socket.send(new Uint8Array([1, 2, 3]).buffer)
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')

--- a/test/node/server.js
+++ b/test/node/server.js
@@ -1,8 +1,8 @@
 // Test the Server class
 
-const Socket = require('../../')
-const Server = require('../../server')
-const test = require('tape')
+import Socket from '../../index.js'
+import Server from '../../server.js'
+import test from 'tape'
 
 test('socket server', function (t) {
   t.plan(5)
@@ -13,16 +13,16 @@ test('socket server', function (t) {
   server.on('connection', function (socket) {
     t.equal(typeof socket.read, 'function') // stream function is present
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'type is buffer')
-      t.equal(data.toString(), 'ping')
+      t.ok(ArrayBuffer.isView(data), 'type is buffer')
+      t.equal(Buffer.from(data).toString(), 'ping')
       socket.write('pong')
     })
   })
 
   const client = new Socket('ws://localhost:' + port)
   client.on('data', function (data) {
-    t.ok(Buffer.isBuffer(data), 'type is buffer')
-    t.equal(data.toString(), 'pong')
+    t.ok(ArrayBuffer.isView(data), 'type is buffer')
+    t.equal(Buffer.from(data).toString(), 'pong')
 
     server.close()
     client.destroy()

--- a/test/node/server.js
+++ b/test/node/server.js
@@ -7,8 +7,8 @@ const test = require('tape')
 test('socket server', function (t) {
   t.plan(5)
 
-  const port = 6789
-  const server = new Server({ port })
+  const server = new Server({ port: 0 })
+  const port = server._server._server.address().port
 
   server.on('connection', function (socket) {
     t.equal(typeof socket.read, 'function') // stream function is present
@@ -30,11 +30,11 @@ test('socket server', function (t) {
   client.write('ping')
 })
 
-test('socket server, with custom encoding', function (t) {
+test('socket server, with objectmode', function (t) {
   t.plan(5)
 
-  const port = 6789
-  const server = new Server({ port, encoding: 'utf8' })
+  const server = new Server({ port: 0, objectMode: true })
+  const port = server._server._server.address().port
 
   server.on('connection', function (socket) {
     t.equal(typeof socket.read, 'function') // stream function is present
@@ -45,7 +45,7 @@ test('socket server, with custom encoding', function (t) {
     })
   })
 
-  const client = new Socket({ url: 'ws://localhost:' + port, encoding: 'utf8' })
+  const client = new Socket({ url: 'ws://localhost:' + port, objectMode: true })
   client.on('data', function (data) {
     t.equal(typeof data, 'string', 'type is string')
     t.equal(data, 'pong')

--- a/test/object-mode.js
+++ b/test/object-mode.js
@@ -1,6 +1,6 @@
-const common = require('./common')
-const Socket = require('../')
-const test = require('tape')
+import common from './common.js'
+import Socket from '../index.js'
+import test from 'tape'
 
 test('echo string {objectMode: true}', function (t) {
   t.plan(4)
@@ -35,8 +35,8 @@ test('echo Buffer {objectMode: true}', function (t) {
     t.pass('connect emitted')
     socket.send(Buffer.from([1, 2, 3]))
     socket.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -59,8 +59,8 @@ test('echo Uint8Array {objectMode: true}', function (t) {
     socket.on('data', function (data) {
       // binary types always get converted to Buffer
       // See: https://github.com/feross/simple-peer/issues/138#issuecomment-278240571
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')
@@ -83,8 +83,8 @@ test('echo ArrayBuffer {objectMode: true}', function (t) {
     socket.on('data', function (data) {
       // binary types always get converted to Buffer
       // See: https://github.com/feross/simple-peer/issues/138#issuecomment-278240571
-      t.ok(Buffer.isBuffer(data), 'data is Buffer')
-      t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct data')
+      t.ok(ArrayBuffer.isView(data), 'data is Uint8')
+      t.deepEqual(data, new Uint8Array(Buffer.from([1, 2, 3])), 'got correct data')
 
       socket.on('close', function () {
         t.pass('destroyed socket')

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,6 +1,6 @@
-const common = require('./common')
-const Socket = require('../')
-const test = require('tape')
+import common from './common.js'
+import Socket from '../index.js'
+import test from 'tape'
 
 test('duplex stream: send data before "connect" event', function (t) {
   t.plan(6)
@@ -10,7 +10,7 @@ test('duplex stream: send data before "connect" event', function (t) {
 
   socket.on('data', function (chunk) {
     t.ok(socket.connected)
-    t.equal(chunk.toString(), 'abc', 'got correct message')
+    t.equal(Buffer.from(chunk).toString(), 'abc', 'got correct message')
     socket.end()
   })
   socket.on('finish', function () {
@@ -33,7 +33,7 @@ test('duplex stream: send data one-way', function (t) {
 
   socket.on('data', function (chunk) {
     t.ok(socket.connected)
-    t.equal(chunk.toString(), 'abc', 'got correct message')
+    t.equal(Buffer.from(chunk).toString(), 'abc', 'got correct message')
     socket.end()
   })
   socket.on('finish', function () {

--- a/test/stream.js
+++ b/test/stream.js
@@ -15,7 +15,7 @@ test('duplex stream: send data before "connect" event', function (t) {
   })
   socket.on('finish', function () {
     t.pass('got socket "finish"')
-    t.ok(socket._writableState.finished)
+    t.ok(socket._writableState.ended)
   })
   socket.on('end', function () {
     t.pass('got socket "end"')
@@ -38,10 +38,15 @@ test('duplex stream: send data one-way', function (t) {
   })
   socket.on('finish', function () {
     t.pass('got socket "finish"')
-    t.ok(socket._writableState.finished)
+    t.ok(socket._writableState.ended)
   })
   socket.on('end', function () {
     t.pass('got socket "end"')
     t.ok(socket._readableState.ended)
   })
+})
+
+test('cleanup', t => {
+  common.server.close()
+  t.end()
 })


### PR DESCRIPTION
https://github.com/webtorrent/webtorrent/issues/1971

the echo server no longer exists, and no services like it exist, so instead we create a server ourselves.

streamx uses "objectMode" by default as it doesn't force Buffer, so I re-implemented forced buffer mode, encoding doesn't exist on streamx, so I changed the test to objectMode as it's pretty much the same result.